### PR TITLE
Fix RemoteResourceNotFound in Request::info when webdav_root includes special characters with ownCloud/NextCloud server

### DIFF
--- a/webdav/client.py
+++ b/webdav/client.py
@@ -765,7 +765,8 @@ class Client(object):
                             continue
                     else:
                         path_with_sep = "{path}{sep}".format(path=path, sep=Urn.separate)
-                        if not path == urn and not path_with_sep == urn:
+                        path_unquoted = unquote(path)
+                        if not path == urn and not path_with_sep == urn and not path_unquoted == urn:
                             continue
 
                     info = dict()


### PR DESCRIPTION
Request::info would fail with webdav.exceptions.RemoteResourceNotFound on NextCloud or ownCloud servers due to a special characters quoting error.

Possibly connected to issues #18 and #22.

Tested on NextCloud 15.0.4.