### PR TITLE
Fix RemoteResourceNotFound in Request::is_dir when webdav_root includes special characters with ownCloud/NextCloud server

### DIFF
--- a/webdav/client.py
+++ b/webdav/client.py
@@ -824,7 +824,9 @@ class Client(object):
                             continue
                     else:
                         path_with_sep = "{path}{sep}".format(path=path, sep=Urn.separate)
-                        if not path == urn and not path_with_sep == urn:
+                        path_unquoted = unquote(path)
+                        
+                        if not path == urn and not path_with_sep == urn and not path_unquoted == urn:
                             continue
                     type = resp.find(".//{DAV:}resourcetype")
                     if type is None:


### PR DESCRIPTION
Request::is_dir would fail with webdav.exceptions.RemoteResourceNotFound on NextCloud or ownCloud servers due to a special characters quoting error.

Possibly connected to issues CloudPolis#18 and CloudPolis#22.

Tested on NextCloud 15.0.4.